### PR TITLE
feat: transaction support

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -1,0 +1,64 @@
+package adbcduck
+
+import (
+	"context"
+	"database/sql/driver"
+	"errors"
+)
+
+type fullConn interface {
+	driver.Conn
+	driver.ConnBeginTx
+	driver.ConnPrepareContext
+	driver.QueryerContext
+}
+type conn struct {
+	fullConn
+
+	tx bool
+}
+
+func (c *conn) BeginTx(ctx context.Context, _ driver.TxOptions) (driver.Tx, error) {
+	if c.tx {
+		return nil, errors.New("adbcduck: transaction already started")
+	}
+	err := c.exec(ctx, "BEGIN TRANSACTION")
+	if err != nil {
+		return nil, err
+	}
+	c.tx = true
+	return tx{c}, nil
+}
+
+func (c *conn) exec(ctx context.Context, query string) error {
+	stmt, err := c.PrepareContext(ctx, query)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		stmtErr := stmt.Close()
+		if stmtErr != nil && err == nil {
+			err = stmtErr
+		}
+	}()
+	_, err = stmt.(driver.StmtExecContext).ExecContext(ctx, nil)
+	return err
+}
+
+type tx struct {
+	c *conn
+}
+
+func (t tx) Commit() error {
+	err := t.c.exec(context.Background(), "COMMIT")
+	// We assume that transaction is no longer active if commit failed.
+	// Most likely reason for failure is that commit/rollback was manually called.
+	t.c.tx = false
+	return err
+}
+
+func (t tx) Rollback() error {
+	err := t.c.exec(context.Background(), "ROLLBACK")
+	t.c.tx = false // see comment above
+	return err
+}

--- a/driver_test.go
+++ b/driver_test.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sclgo/adbcduck-go"
@@ -14,8 +13,14 @@ import (
 func TestE2E(t *testing.T) {
 	db, err := sql.Open(adbcduck.DriverName, "")
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
 	err = db.Ping()
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	tx, err := db.Begin()
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
 	err = db.Close()
 	require.NoError(t, err)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/sclgo/adbcduck-go
 go 1.23.6
 
 require (
-	github.com/apache/arrow-adbc/go/adbc v1.4.0
+	github.com/apache/arrow-adbc/go/adbc v1.5.0
 	github.com/murfffi/getaduck v0.1.0
 	github.com/stretchr/testify v1.10.0
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/ansel1/merry/v2 v2.2.1 h1:PJpynLFvIpJkn8ZGgNHLq332zIyBc/wTqp3o42ZpWdU
 github.com/ansel1/merry/v2 v2.2.1/go.mod h1:K9lCkM6tJ8s7LQVQ0ZmZ0WrB3BCyr+ZDzoqotzzoxpI=
 github.com/apache/arrow-adbc/go/adbc v1.4.0 h1:I21y3Pq9ygtsmbwNgDZ3dsWRgtuOVMWIVBTdpWeEOCQ=
 github.com/apache/arrow-adbc/go/adbc v1.4.0/go.mod h1:fBbhukk/BpKLGfYquN/ru3ru1Ipl4e+IVqsBtCfWMJc=
+github.com/apache/arrow-adbc/go/adbc v1.5.0 h1:7PM/UiBS8CaCQPi7IG4l8r0kdWn79nX7BHhO9640VQk=
+github.com/apache/arrow-adbc/go/adbc v1.5.0/go.mod h1:sWBqbocybjMizoE67IkTzbFP7B6sryE8gq6uUooBsDY=
 github.com/apache/arrow-go/v18 v18.1.1-0.20250116162745-f533d2066dee h1:LRDJtjipOzw1j1P1VedYDBIZvDVfz+lj1abQ998VGms=
 github.com/apache/arrow-go/v18 v18.1.1-0.20250116162745-f533d2066dee/go.mod h1:WbR+28APHo5LrJrHfwGPWRpWEtejDAUWRF3yoSLpSx4=
 github.com/apache/thrift v0.21.0 h1:tdPmh/ptjE1IJnhbhrcl2++TauVjy242rkV/UzJChnE=


### PR DESCRIPTION
Add support for transactions. The transaction support in the underlying arrow-adbc/sqldriver is only for databases that control transactions with SET AUTOCOMMIT=0 . DBs, that use BEGIN TRANSACTION statement, like DuckDB, need the extension in this PR.

Also updated deps.

Testing Done: extended e2e test