### PR TITLE
fix: fix converting decimals to string

### DIFF
--- a/internal/sqldriver/driver.go
+++ b/internal/sqldriver/driver.go
@@ -37,6 +37,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/decimal128"
 	"github.com/apache/arrow-go/v18/arrow/decimal256"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/sclgo/adbcduck-go/types"
 )
 
 func parseConnectStr(str string) (ret map[string]string, err error) {
@@ -652,9 +653,15 @@ func getValue(col arrow.Array, idx int) (driver.Value, error) {
 	case *array.Timestamp:
 		value = col.Value(idx).ToTime(col.DataType().(*arrow.TimestampType).Unit)
 	case *array.Decimal128:
-		value = col.Value(idx)
+		value = types.Decimal[decimal128.Num]{
+			Num:   col.Value(idx),
+			Scale: col.DataType().(arrow.DecimalType).GetScale(),
+		}
 	case *array.Decimal256:
-		value = col.Value(idx)
+		value = types.Decimal[decimal256.Num]{
+			Num:   col.Value(idx),
+			Scale: col.DataType().(arrow.DecimalType).GetScale(),
+		}
 	case array.ListLike:
 		i, j := col.ValueOffsets(idx)
 		listVal := make([]driver.Value, j-i)

--- a/internal/sqldriver/driver_internals_test.go
+++ b/internal/sqldriver/driver_internals_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/decimal128"
 	"github.com/apache/arrow-go/v18/arrow/decimal256"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/sclgo/adbcduck-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -254,7 +255,10 @@ func TestNextRowTypes(t *testing.T) {
 				t.Helper()
 				b.(*array.Decimal128Builder).Append(decimal128.FromU64(10))
 			},
-			golangValue: decimal128.FromU64(10),
+			golangValue: types.Decimal[decimal128.Num]{
+				Num:   decimal128.FromU64(10),
+				Scale: 2,
+			},
 		},
 		{
 			arrowType: &arrow.Decimal256Type{Precision: 10, Scale: 5},
@@ -262,7 +266,10 @@ func TestNextRowTypes(t *testing.T) {
 				t.Helper()
 				b.(*array.Decimal256Builder).Append(decimal256.FromU64(10))
 			},
-			golangValue: decimal256.FromU64(10),
+			golangValue: types.Decimal[decimal256.Num]{
+				Num:   decimal256.FromU64(10),
+				Scale: 5,
+			},
 		},
 		{
 			arrowType: arrow.SparseUnionOf([]arrow.Field{stringField, int32Field}, []arrow.UnionTypeCode{0, 1}),

--- a/types/decimal.go
+++ b/types/decimal.go
@@ -1,0 +1,22 @@
+package types
+
+import (
+	"fmt"
+
+	"github.com/apache/arrow-go/v18/arrow/decimal"
+)
+
+// Decimal extends the arrow.Decimal[T] with a record of the source scale value
+// which adds the ability to print the number
+type Decimal[T decimal.DecimalTypes] struct {
+	decimal.Num[T]
+	// The original scale of the decimal
+	Scale int32
+}
+
+// String implements fmt.Stringer
+func (d Decimal[T]) String() string {
+	return d.ToString(d.Scale)
+}
+
+var _ fmt.Stringer = Decimal[decimal.Decimal128]{}

--- a/types/doc.go
+++ b/types/doc.go
@@ -1,0 +1,2 @@
+// Package types adapts arrow data types to DuckDB
+package types


### PR DESCRIPTION
Now fmt.Sprint(decimal) produces reasonable output. CLIs like usql also print decimals reasonably.